### PR TITLE
Fix numbering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ https://github.com/brandenespinoza/gilfoyle/assets/53885863/e6ed4db1-cd3b-4125-a
 
 1. Key "2".
 2. Press **Enter**.
-5. Key the desired polling frequency in seconds.
-6. Press **Enter**.
+3. Key the desired polling frequency in seconds.
+4. Press **Enter**.
 
 <hr>
 


### PR DESCRIPTION
## Summary
- fix sequential step numbers for JERRY GARCIA MODE in README

## Testing
- `python3 -m py_compile gilfoyle.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b427764e483219f201c0042178e5c